### PR TITLE
 Add plugin support to run NDSes for data files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ The bootstrap.cia file can be installed on a 3DS using FBI. This requires boot.n
 
 Place your homebrew games in the /nds folder and have fun.
 
+## Plugins
+
+The Homebrew Menu supports using plugins to handle data other than `.nds` files. For example, you can use a plugin to browse for music or videos in the Homebrew Menu then play it using its own player program.
+
+To install a plugin, name it `<filetype>.nds`, where `<filetype>` is the type of file it handles, then copy it to a `/nds/plugins` on your card.
+
+E.g. if you have a video player that plays `.avi` files, copy it onto your card at `/nds/plugins/avi.nds`.
+
+## `.argv` files
+
 The Homebrew Menu also supports passing arguments to launched .nds files via .argv files. The testfiles folder has an nds file which lists arguments and some sample .argv files. These are simple text files which start with the name of the nds file to run and a list of arguments to pass to the application. Here's a quick sample .argv file.
 ```shell
 # This is a comment

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -159,7 +159,14 @@ int main(int argc, char **argv) {
 
 	loadPlugins(extensionList, PLUGIN_DIR, NDS_EXT);
 
-	chdir("/nds");
+	if (extensionList.size() == 2) {
+		// Browse the NDS directory when there are no plugins loaded
+		chdir("/nds");
+	} else {
+		// Start at the root directory if there are plugins, since data files
+		// could be anywhere
+		chdir("/");
+	}
 
 	while(1) {
 

--- a/source/plugin.cpp
+++ b/source/plugin.cpp
@@ -1,0 +1,59 @@
+/*-----------------------------------------------------------------
+ Copyright (C) 2018
+	Michael "Chishm" Chisholm
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+------------------------------------------------------------------*/
+
+#include "plugin.h"
+#include <dirent.h>
+#include <string>
+#include <cstring>
+#include <unistd.h>
+#include <sys/stat.h>
+
+using namespace std;
+
+void loadPlugins (vector<string>& extensions, const char *pluginDir, const char *pluginExt) {
+	DIR *pdir = opendir (pluginDir);
+	size_t pluginExtLen = strlen(pluginExt);
+	struct dirent* pent;
+
+	while( (pent = readdir(pdir)) != NULL ) {
+		if (pent->d_type != DT_REG) {
+			// Only examine files
+			continue;
+		}
+
+		size_t name_len = strlen(pent->d_name);
+		if (name_len <= pluginExtLen) {
+			// File name is not long enough
+			continue;
+		}
+
+		if (strcasecmp(pent->d_name + name_len - pluginExtLen, pluginExt) != 0) {
+			// Doesn't end in the NDS extension
+			continue;
+		}
+
+		// The plugin name up until the ".nds" is what file extensions it handles
+		pent->d_name[name_len - pluginExtLen] = '\0';
+
+		extensions.push_back(pent->d_name);
+	}
+
+	closedir(pdir);
+}

--- a/source/plugin.h
+++ b/source/plugin.h
@@ -1,0 +1,30 @@
+/*-----------------------------------------------------------------
+ Copyright (C) 2018
+	Michael "Chishm" Chisholm
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+------------------------------------------------------------------*/
+
+#ifndef PLUGIN_H
+#define PLUGIN_H
+
+#include <string>
+#include <vector>
+
+// Return a list of handled file extensions for the list of NDS files in the plugins directory
+void loadPlugins (std::vector<std::string>& extensions, const char *pluginDir, const char *pluginExt);
+
+#endif //PLUGIN_H


### PR DESCRIPTION
Add a new mechanism to construct command lines to run an NDS program with a selected data file as the argument. Plugins are placed in the `/nds/plugins/` directory with the file extension they handle as the
name and an nds extension.

E.g. copy `tuna-vids.nds` to `/nds/plugins/avi.nds` and then you will be able to browse for and play `.avi` files.